### PR TITLE
added configurable locust trial job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,3 +41,23 @@ jobs:
         labels: ${{ steps.stormforger_docker_meta.outputs.labels }}
     - name: StormForger image digest
       run: echo ${{ steps.stormforger_docker_build.outputs.digest }}
+
+    - name: Locust Docker meta
+      id: locust_docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tag-sha: true
+        tag-edge: true
+        sep-tags: -locust,
+    - name: Locust build and push
+      id: locust_docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./locust
+        file: ./locust/Dockerfile
+        push: true
+        tags: ${{ steps.locust_docker_meta.outputs.tags }}-locust
+        labels: ${{ steps.locust_docker_meta.outputs.labels }}
+    - name: Locust image digest
+      run: echo ${{ steps.locust_docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ This repository is a collection of containers suitable for use as trial jobs dur
 ### StormForger
 
 The StormForger trial job invokes a [StormForger](https://stormforger.com/) test case against your application, with each trial corresponding to a test run.
+
+### Locust
+
+The Locust trial job creates a [Locust](https://locust.io/) load test parametrized via environment variables.

--- a/locust/Dockerfile
+++ b/locust/Dockerfile
@@ -1,6 +1,11 @@
-FROM grubykarol/locust:1.2.3-python3.9-alpine3.12
+FROM locustio/locust
 
-RUN apk add --no-cache curl jq
-COPY parse_metrics.py docker-entrypoint.sh /locust/
+USER root
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+RUN apt-get update && \
+    apt-get -y install curl jq
+COPY parse_metrics.py /locust/
+WORKDIR /locust
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/locust/Dockerfile
+++ b/locust/Dockerfile
@@ -1,0 +1,6 @@
+FROM grubykarol/locust:1.2.3-python3.9-alpine3.12
+
+RUN apk add --no-cache curl jq
+COPY parse_metrics.py docker-entrypoint.sh /locust/
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/locust/README.md
+++ b/locust/README.md
@@ -6,13 +6,39 @@ The metrics are then pushed to the prometheus push gateway.
 
 ## Configuration
 
-| Environment Variable | Description |
-| -------------------- | ----------- |
-| `HOST`               | Host to load test in the following format: "http://10.21.32.33" |
-| `NUM_USERS`            | Number of concurrent locust users |
-| `SPAWN_RATE`         |The rate per second in which users are spawned |
-| `RUN_TIME`           | Duration of the load test in seconds |
-| `PUSHGATEWAY_URL`    | The URL used push StormForger test run metrics. |
+| Environment Variable | Description | Default Value |
+| -------------------- | ----------- | ------------- |
+| `HOST`               | Host to load test in the following format: "http://10.21.32.33" | "http://localhost:8000" |
+| `NUM_USERS`          | Number of concurrent locust users | 200 |
+| `SPAWN_RATE`         |The rate per second in which users are spawned | 20 |
+| `RUN_TIME`           | Duration of the load test in seconds | 180 |
+| `PUSHGATEWAY_URL`    | The URL used to push Locust test run metrics. | "http://prometheus:9091/metrics/job/trialRun" |
+
+## Locust Metrics
+
+The following metrics are collected at the end of the job and pushed to
+`PUSHGATEWAY_URL`:
+```shell script
+  "request_count": 307,
+  "failure_count": 0,
+  "average_response_time": 335.0972685700326,
+  "min_response_time": 149.37174799999963,
+  "max_response_time": 863.829511,
+  "average_content_size": 60283.4332247557,
+  "requests_per_s": 34.08458474131345,
+  "failures_per_s": 0,
+  "p50": 260,
+  "p66": 360,
+  "p75": 430,
+  "p80": 480,
+  "p90": 650,
+  "p95": 720,
+  "p98": 770,
+  "p99": 800,
+  "p99_9": 860,
+  "p99_99": 860,
+  "p100": 860
+``` 
 
 ## Example Kubernetes Manifest
 
@@ -51,11 +77,11 @@ spec:
         - name: HOST
           value: "http://api-endpoint:port-number"
         - name: NUM_USERS
-          value: "400"
+          value: "200"
         - name: SPAWN_RATE
           value: "20"
         - name: RUN_TIME
-          value: "30"
+          value: "180"
         - name: PUSHGATEWAY_URL
           value: "http://prometheus:9091/metrics/job/trialRun/instance/locust-1"
         volumeMounts:

--- a/locust/README.md
+++ b/locust/README.md
@@ -1,0 +1,81 @@
+# Trial Job - Locust
+
+The Locust job uses Locust v1.2.3 to launch a load test
+performed by locust and collect the metrics at the end of the job.
+The metrics are then pushed to the prometheus push gateway.
+
+## Configuration
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| `HOST`               | Host to load test in the following format: "http://10.21.32.33" |
+| `NUM_USERS`            | Number of concurrent locust users |
+| `SPAWN_RATE`         |The rate per second in which users are spawned |
+| `RUN_TIME`           | Duration of the load test in seconds |
+| `PUSHGATEWAY_URL`    | The URL used push StormForger test run metrics. |
+
+## Example Kubernetes Manifest
+
+The following Kubernetes Job manifest illustrates how you
+might leverage this trial job container. The environment variables
+are the arguments to the locust CLI and the prometheus
+pushgateway url. The locustfile is passed via a ConfigMap.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: locustconfig
+data:
+  locustfile.py: |
+    from locust import HttpUser, task, between
+    class MyUser(HttpUser):
+        wait_time = between(1, 5)
+        @task(1)
+        def index(self):
+            self.client.get("/api-url/endpoint/")
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: locust-1
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: locust
+        image: redskyops/trial-jobs:0.0.1-locust
+        env:
+        - name: HOST
+          value: "http://api-endpoint:port-number"
+        - name: NUM_USERS
+          value: "400"
+        - name: SPAWN_RATE
+          value: "20"
+        - name: RUN_TIME
+          value: "30"
+        - name: PUSHGATEWAY_URL
+          value: "http://prometheus:9091/metrics/job/trialRun/instance/locust-1"
+        volumeMounts:
+          - name: locustconfig
+            mountPath: /locust/locustfile.py
+            subPath: locustfile.py
+      volumes:
+      - name: locustconfig
+        configMap:
+          name: locustconfig
+      - name: podinfo
+        downwardAPI:
+          items:
+          - path: labels
+            fieldRef:
+              fieldPath: metadata.labels
+```
+
+NOTE: If you are using this in an experiment,
+keep in mind that some values are set automatically.
+In particular, the `backoffLimit`, `restartPolicy`, and
+`PUSHGATEWAY_URL` environment variable are all introduced when
+evaluating a trial's job template.

--- a/locust/docker-entrypoint.sh
+++ b/locust/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+locust -f locustfile.py \
+  --host "${HOST}" \
+  --user "${NUM_USERS}" \
+  --spawn-rate "${SPAWN_RATE}" \
+  --headless \
+  --run-time "${RUN_TIME}" \
+  --csv "locust"
+
+# parse locust metrics
+python parse_metrics.py --metrics_file locust_stats.csv \
+  --output_file output.json
+
+cat "output.json" \
+  | jq -r '.|keys[] as $k | "\($k) \(.[$k])"' \
+  | curl --data-binary @- "${PUSHGATEWAY_URL}"

--- a/locust/docker-entrypoint.sh
+++ b/locust/docker-entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+set -e
+
+HOST=${HOST:-http://localhost:8000}
+NUM_USERS=${NUM_USERS:-200}
+SPAWN_RATE=${SPAWN_RATE:-20}
+RUN_TIME=${RUN_TIME:-180}
+PUSHGATEWAY_URL=${LOAD_TEST_PAUSE:-http://prometheus:9091/metrics/job/trialRun}
 
 locust -f locustfile.py \
   --host "${HOST}" \
@@ -9,8 +16,7 @@ locust -f locustfile.py \
   --csv "locust"
 
 # parse locust metrics
-python parse_metrics.py --metrics_file locust_stats.csv \
-  --output_file output.json
+python parse_metrics.py --metrics_file locust_stats.csv
 
 cat "output.json" \
   | jq -r '.|keys[] as $k | "\($k) \(.[$k])"' \

--- a/locust/docker-entrypoint.sh
+++ b/locust/docker-entrypoint.sh
@@ -5,7 +5,6 @@ HOST=${HOST:-http://localhost:8000}
 NUM_USERS=${NUM_USERS:-200}
 SPAWN_RATE=${SPAWN_RATE:-20}
 RUN_TIME=${RUN_TIME:-180}
-PUSHGATEWAY_URL=${LOAD_TEST_PAUSE:-http://prometheus:9091/metrics/job/trialRun}
 
 locust -f locustfile.py \
   --host "${HOST}" \

--- a/locust/parse_metrics.py
+++ b/locust/parse_metrics.py
@@ -12,14 +12,20 @@ def parse_metric_key(key):
 
 
 def main(args):
-    # Fetch metrics from locust csv and create json output
+    """
+    Fetch metrics from locust csv and create raw metrics for
+    the prometheus push gateway The metrics pushed are
+    detailed in the README
+    """
     for row in csv.DictReader(open(args.metrics_file)):
         if row["Name"] == "Aggregated":
             row.pop("Type")
             row.pop("Name")
+            row.pop("Median Response Time")
             row = {parse_metric_key(k): float(v) for k, v in row.items()}
-            with open(args.output_file, 'w') as fp:
-                json.dump(row, fp)
+            metrics_dict = row
+    with open("output.json", "w") as fp:
+        json.dump(metrics_dict, fp)
 
 
 if __name__ == '__main__':
@@ -27,10 +33,6 @@ if __name__ == '__main__':
     ARGPARSER.add_argument("--metrics_file",
                            help="locust metrics csv file",
                            default="locust_stats.csv",
-                           type=str)
-    ARGPARSER.add_argument("--output_file",
-                           help="output json file",
-                           default="output.json",
                            type=str)
     ARGS = ARGPARSER.parse_args()
     main(ARGS)

--- a/locust/parse_metrics.py
+++ b/locust/parse_metrics.py
@@ -1,0 +1,36 @@
+import csv
+import json
+import argparse
+
+
+def parse_metric_key(key):
+    key = key.lower().replace(" ", "_").replace("/", "_per_").replace(".", "_")
+    if "%" in key:
+        key = key.replace("%", "")
+        key = "p" + key
+    return key
+
+
+def main(args):
+    # Fetch metrics from locust csv and create json output
+    for row in csv.DictReader(open(args.metrics_file)):
+        if row["Name"] == "Aggregated":
+            row.pop("Type")
+            row.pop("Name")
+            row = {parse_metric_key(k): float(v) for k, v in row.items()}
+            with open(args.output_file, 'w') as fp:
+                json.dump(row, fp)
+
+
+if __name__ == '__main__':
+    ARGPARSER = argparse.ArgumentParser()
+    ARGPARSER.add_argument("--metrics_file",
+                           help="locust metrics csv file",
+                           default="locust_stats.csv",
+                           type=str)
+    ARGPARSER.add_argument("--output_file",
+                           help="output json file",
+                           default="output.json",
+                           type=str)
+    ARGS = ARGPARSER.parse_args()
+    main(ARGS)


### PR DESCRIPTION
This introduces the locust trial job which launches locust on a host (host, n_user and spawn_rate are parametrized via env variable). At the end of the job, the locust metrics are collected and parsed and then sent to the prometheus push gateway.

The locustfile is passed via a configmap, see example in README.md