### PR TITLE
Ensure the test case name starts with an organization name

### DIFF
--- a/stormforge-perf/docker-entrypoint.sh
+++ b/stormforge-perf/docker-entrypoint.sh
@@ -6,6 +6,12 @@ set -e
 forge ping
 
 
+# Make sure TEST_CASE has an organization, just take the first one
+if [ "${TEST_CASE}" = "$(basename ${TEST_CASE})" ] ; then
+	TEST_CASE="$(forge organization list --output plain | head -1)/${TEST_CASE}"
+fi
+
+
 # Launch the test case
 args=(--watch --output json)
 


### PR DESCRIPTION
This change ensures that a test case starts with an organization name (as is required by `forge`). If the organization name is missing, the first organization the user belongs to will be prepended to the test case name.

The selection of the first organization name is arbitrary, the alternative would be to select the _only_ organization name and fail the load test if multiple organizations are present (requiring manual disambiguation, i.e. putting the right prefix on `TEST_CASE` to start with). Given that the outcome (needing to set a more specific value for `TEST_CASE`) would be the same if the incorrect (first) organization was selected vs. outright failing, this seemed easier (and only slightly less likely to fail).