### PR TITLE
Change k6 script path environment variable

### DIFF
--- a/.github/workflows/test-k6.yaml
+++ b/.github/workflows/test-k6.yaml
@@ -49,7 +49,7 @@ jobs:
           --network sf-test \
           -v ${PWD}/test:/test \
           --env PUSHGATEWAY_URL=http://pushgateway:9091/metrics/job/sf_k6_test \
-          --env TEST_CASE_FILE=/test/simple.js \
+          --env SCRIPT_FILE=/test/simple.js \
           --env SF_K6_TARGET=http://testapp:8080 \
           sf-k6-test
 

--- a/k6/README.md
+++ b/k6/README.md
@@ -11,7 +11,7 @@ the metrics need to be translated to be pushable to Prometheus. As a result, we 
 
 | Environment Variable | Description |
 | -------------------- | ----------- |
-| `TEST_CASE_FILE`     | Path to the test case file mounted in the container. Defaults to `/scripts/script.js`. Associated volume mount is required that contains this file. If the file is not found, the trial fails. |
+| `SCRIPT_FILE`        | Path to the test script file mounted in the container. Defaults to `/scripts/script.js`. Associated volume mount is required that contains this file. If the file is not found, the trial fails. |
 | `PUSHGATEWAY_URL`    | The URL used to push K6 test run metrics. If not explicitly set, the Optimize controller will set it. |
 
 ## Metrics
@@ -108,7 +108,7 @@ spec:
       - name: black-friday
         image: thestormforge/optimize-trials:k6-latest
         env:
-        - name: TEST_CASE_FILE
+        - name: SCRIPT_FILE
           value: /scripts/blackfriday.js
         - name: PUSHGATEWAY_URL
           value: http://pushgateway:9091/metrics/job/trialRun/instance/sandbox-1

--- a/k6/docker-entrypoint.sh
+++ b/k6/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 set -e
 
-# Check for the test case file via either a passed-in env path or the default
+# Check for the test script file via either a passed-in env path or the default
 # In either case, the file should be mounted as a volume (from configmap, etc)
-TEST_CASE_FILE=${TEST_CASE_FILE:-"/scripts/script.js"}
+SCRIPT_FILE=${SCRIPT_FILE:-"/scripts/script.js"}
 
-if ! [ -f "${TEST_CASE_FILE}" ]; then
-  echo "A test case JS file must be provided."
+if ! [ -f "${SCRIPT_FILE}" ]; then
+  echo "A test script file must be provided."
   exit 1
 fi
 
@@ -26,19 +26,19 @@ if [ -n "${PUSHGATEWAY_URL}" ]; then
   echo
 fi
 
-COMBINED_TEST_CASE_FILE="/tmp/combined_script.js"
+COMBINED_SCRIPT_FILE="/tmp/combined_script.js"
 
 # Check for a custom handleSummary() in the provided script, add it otherwise
-cp "${TEST_CASE_FILE}" ${COMBINED_TEST_CASE_FILE}
-grep -q "export \+function \+handleSummary" "${TEST_CASE_FILE}" || cat "${TEST_CASE_FILE}" handleSummary.js > "${COMBINED_TEST_CASE_FILE}"
+cp "${SCRIPT_FILE}" ${COMBINED_SCRIPT_FILE}
+grep -q "export \+function \+handleSummary" "${SCRIPT_FILE}" || cat "${SCRIPT_FILE}" handleSummary.js > "${COMBINED_SCRIPT_FILE}"
 
-# Run the test case. If we used the default handleSummary.js snippet, the output
+# Run the test script. If we used the default handleSummary.js snippet, the output
 # file will be called prometheus.txt. If handleSummary was provided as part of
-# the test case js file, PROMETHEUS_OUTPUT_FILE will need to be set to the corresponding output file namespace
+# the test script file, PROMETHEUS_OUTPUT_FILE will need to be set to the corresponding output file namespace
 echo
 echo "Launching k6 test..."
 # shellcheck disable=SC2086
-k6 run ${SF_K6_ARGS} "${COMBINED_TEST_CASE_FILE}"
+k6 run ${SF_K6_ARGS} "${COMBINED_SCRIPT_FILE}"
 
 printf "\nk6 run complete"
 
@@ -46,7 +46,7 @@ printf "\nk6 run complete"
 if [ -n "${PUSHGATEWAY_URL}" ]; then
   # Check, if our handleSummary function wrote its output
   if ! [ -f "${PROMETHEUS_OUTPUT_FILE}" ]; then
-    echo "Test case output was not found at ${PROMETHEUS_OUTPUT_FILE}. Unable to push to Prometheus."
+    echo "Test script output was not found at ${PROMETHEUS_OUTPUT_FILE}. Unable to push to Prometheus."
     exit 1
   fi
 


### PR DESCRIPTION
Change "test case" to "test script" (or more concisely "script") to better match k6 terminology.