### PR TITLE
fix: Link to grafana/k6 image on DockerHub

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -1,7 +1,7 @@
 # k6 Trial Job
 
 The k6 trial job leverages a custom k6 container, based on the [public
-`grafana/k6` container image](https://hub.docker.com/r/loadimpact/k6), to launch a provided test case. The image will
+`grafana/k6` container image](https://hub.docker.com/r/grafana/k6), to launch a provided test case. The image will
 check to make sure the provided test script exists. It is expected that the test script is valid k6 test case ([see k6 docs](https://k6.io/docs/using-k6/)) available in the container at runtime.
 
 In order to make the k6 output metrics usable by the Optimize Pro


### PR DESCRIPTION
The `k6/Dockerfile` is based on `grafana/k6`, not `loadimpact/k6`. We should link to the correct image on the Docker Hub.