### PR TITLE
refactor: Make sure the name of the ENV var is printed for PUSHGATEWAY_URL error

### DIFF
--- a/k6/docker-entrypoint.sh
+++ b/k6/docker-entrypoint.sh
@@ -62,4 +62,6 @@ if [ -n "${PUSHGATEWAY_URL}" ]; then
     echo "Uploading to Pushgateway failed, curl exit code ${PUSH_OK}"
     exit $PUSH_OK
   fi
+else
+  echo "WARN: No PUSHGATEWAY_URL configured" > /dev/stderr
 fi

--- a/locust/docker-entrypoint.sh
+++ b/locust/docker-entrypoint.sh
@@ -15,5 +15,5 @@ if [ -n "${PUSHGATEWAY_URL}" ]; then
 		| jq -r '.|keys[] as $k | "\($k) \(.[$k])"' \
 		| curl --data-binary @- "${PUSHGATEWAY_URL}"
 else
-	echo "No Pushgateway URL" 1>&2
+	echo "WARN: No PUSHGATEWAY_URL configured" > /dev/stderr
 fi

--- a/stormforge-perf/docker-entrypoint.sh
+++ b/stormforge-perf/docker-entrypoint.sh
@@ -55,5 +55,5 @@ if [ -n "${PUSHGATEWAY_URL}" ]; then
 		| jq -r '.data.attributes.basic_statistics|keys[] as $k | "\($k) \(.[$k])"' \
 		| curl --data-binary @- "${PUSHGATEWAY_URL}"
 else
-	echo "No Pushgateway URL" 1>&2
+	echo "WARN: No PUSHGATEWAY_URL configured" > /dev/stderr
 fi


### PR DESCRIPTION
This PR aligns the error message printed by our trial containers if no `PUSHGATEWAY_URL` is given.