### PR TITLE
Add BlazeMeter Cloud to build actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,3 +35,9 @@ jobs:
     uses: ./.github/workflows/build-push.yaml
     with:
       dir: jmeter
+
+  blazemeter-cloud:
+    name: BlazeMeter Cloud
+    uses: ./.github/workflows/build-push.yaml
+    with:
+      dir: blazemeter-cloud

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,3 +46,13 @@ jobs:
     secrets:
       username: ${{ secrets.DOCKERHUB_USERNAME }}
       password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  blazemeter-cloud:
+    name: BlazeMeter Cloud
+    uses: ./.github/workflows/promote.yaml
+    with:
+      dir: blazemeter-cloud
+      version: ${{ github.event.release.tag_name }}
+    secrets:
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the BlazeMeter Cloud trial image to the image build actions so that an image is built on pushes to main/releases/etc. It follows the same pattern as the other trial images.